### PR TITLE
Fix table generation to avoid duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,7 @@
 <body>
     <table>
         <tbody>
-            <!-- Generate 8x8 grid -->
-            <script>
-                for (let i = 0; i < 8; i++) {
-                    document.write('<tr>');
-                    for (let j = 0; j < 8; j++) {
-                        document.write('<td>' + (i * 8 + j + 1) + '</td>');
-                    }
-                    document.write('</tr>');
-                }
-            </script>
+            <!-- Empty tbody -->
         </tbody>
     </table>
     <script src="script.js"></script>


### PR DESCRIPTION
Remove the table generation script from `index.html`.

* **index.html**
  - Remove the script that generates the 8x8 grid.
  - Keep the table element with an empty tbody.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mattan/llm-ai-pirate-game/pull/12?shareId=029eb7e3-f601-4892-a6ad-b02a46c66c99).